### PR TITLE
`[ENG-758]` Typesafe disabling of queries using skipToken

### DIFF
--- a/src/react/hooks/useApiChains.ts
+++ b/src/react/hooks/useApiChains.ts
@@ -1,20 +1,24 @@
 import { useContext, useQuery } from './imports';
 import { SupportedChainId } from '../../core/types/Chains';
 import { apiChains } from '../../core/fetch/meta';
-import { QueryReturn } from '../types';
+import { QueryReturn, TanstackQueryOptions } from '../types';
 import { DecentApiContext } from '../contexts/DecentApiContext';
+import { skipToken } from '@tanstack/react-query';
+
+type ApiChainsParams = TanstackQueryOptions;
 
 /**
  * React hook to fetch the list of supported chains from the API.
  *
  * @returns {QueryReturn<SupportedChainId[]>} Object with { data: SupportedChainId[], loading: boolean, error: Error | null }
  */
-export const useApiChains = (): QueryReturn<SupportedChainId[]> => {
+export const useApiChains = (params: ApiChainsParams): QueryReturn<SupportedChainId[]> => {
   const { apiUrl } = useContext(DecentApiContext);
+  const shouldFetch = params.enabled;
   const { data, error, isLoading } = useQuery({
     queryKey: ['chains', apiUrl],
-    queryFn: () => apiChains({ apiUrl }),
-    initialData: [],
+    queryFn: shouldFetch ? () => apiChains({ apiUrl }) : skipToken,
+    initialData: []
   });
 
   return { data, isLoading, error };

--- a/src/react/hooks/useApiHealth.ts
+++ b/src/react/hooks/useApiHealth.ts
@@ -1,21 +1,24 @@
 import { useContext, useQuery } from './imports';
 import { Health } from '../../core/types/Api';
 import { apiHealth } from '../../core/fetch/meta';
-import { QueryReturn } from '../types';
+import { QueryReturn, TanstackQueryOptions } from '../types';
 import { DecentApiContext } from '../contexts/DecentApiContext';
+import { skipToken } from '@tanstack/react-query';
+
+type ApiHealthParams = TanstackQueryOptions;
 
 /**
  * React hook to fetch API health status.
  *
  * @returns {QueryReturn<Health>} Object with { data: Health, loading: boolean, error: Error | null }
  */
-export const useApiHealth = (): QueryReturn<Health> => {
+export const useApiHealth = (params: ApiHealthParams): QueryReturn<Health> => {
   const { apiUrl } = useContext(DecentApiContext);
-
+  const shouldFetch = params.enabled;
   const { data, error, isLoading } = useQuery({
     queryKey: ['health', apiUrl],
-    queryFn: () => apiHealth({ apiUrl }),
-    initialData: '',
+    queryFn: shouldFetch ? () => apiHealth({ apiUrl }) : skipToken,
+    initialData: ''
   });
 
   return { data, isLoading, error };

--- a/src/react/hooks/useApiInfo.ts
+++ b/src/react/hooks/useApiInfo.ts
@@ -1,21 +1,24 @@
 import { useContext, useQuery } from './imports';
 import { Meta } from '../../core/types/Api';
 import { apiInfo } from '../../core/fetch/meta';
-import { QueryReturn } from '../types';
+import { QueryReturn, TanstackQueryOptions } from '../types';
 import { DecentApiContext } from '../contexts/DecentApiContext';
+import { skipToken } from '@tanstack/react-query';
+
+type ApiInfoParams = TanstackQueryOptions;
 
 /**
  * React hook to fetch API metadata information.
  *
  * @returns {QueryReturn<Meta>} Object with { data: Meta, loading: boolean, error: Error | null }
  */
-export const useApiInfo = (): QueryReturn<Meta> => {
+export const useApiInfo = (params: ApiInfoParams): QueryReturn<Meta> => {
   const { apiUrl } = useContext(DecentApiContext);
-
+  const shouldFetch = params.enabled;
   const { data, error, isLoading } = useQuery({
     queryKey: ['meta', apiUrl],
-    queryFn: () => apiInfo({ apiUrl }),
-    initialData: { name: '', version: '' },
+    queryFn: shouldFetch ? () => apiInfo({ apiUrl }) : skipToken,
+    initialData: { name: '', version: '' }
   });
 
   return { data, isLoading, error };

--- a/src/react/hooks/useFetchComments.ts
+++ b/src/react/hooks/useFetchComments.ts
@@ -3,14 +3,17 @@ import { SupportedChainId } from '../../core/types/Chains';
 import { Comment } from '../../core/types/Discussion';
 import { Address } from '../../core/types/Common';
 import { getAllComments } from '../../core/fetch/comment';
-import { QueryReturn } from '../types';
+import { QueryReturn, TanstackQueryOptions } from '../types';
 import { DecentApiContext } from '../contexts/DecentApiContext';
+import { skipToken } from '@tanstack/react-query';
 
-type FetchCommentsParams = {
+type FetchCommentsOptions = {
   chainId?: SupportedChainId;
   address?: Address;
   slug?: string;
 };
+
+type FetchCommentsParams = FetchCommentsOptions & TanstackQueryOptions;
 
 /**
  * React hook to fetch all comments for a specific proposal.
@@ -22,16 +25,12 @@ type FetchCommentsParams = {
  * @returns {QueryReturn<Comment[]>} Object with { data: Comment[], isLoading: boolean, error: Error | null }
  */
 export const useFetchComments = (params: FetchCommentsParams): QueryReturn<Comment[]> => {
-  const { chainId, address, slug } = params;
+  const { chainId, address, slug, enabled } = params;
   const { apiUrl } = useContext(DecentApiContext);
-  const shouldFetch = !!(chainId && address && slug);
-  if (!shouldFetch) {
-    return { data: [], isLoading: false, error: null };
-  }
+  const shouldFetch = !!(chainId && address && slug) && enabled;
   const { data, error, isLoading } = useQuery({
     queryKey: ['comments', chainId, address, slug, apiUrl],
-    queryFn: () => getAllComments({ chainId, address, slug, apiUrl }),
-    enabled: shouldFetch,
+    queryFn: shouldFetch ? () => getAllComments({ chainId, address, slug, apiUrl }) : skipToken,
     initialData: [],
   });
 

--- a/src/react/hooks/useFetchDao.ts
+++ b/src/react/hooks/useFetchDao.ts
@@ -3,13 +3,16 @@ import { Dao } from '../../core/types/Dao';
 import { Address } from '../../core/types/Common';
 import { SupportedChainId } from '../../core/types/Chains';
 import { getDao } from '../../core/fetch/dao';
-import { QueryReturn } from '../types';
+import { QueryReturn, TanstackQueryOptions } from '../types';
 import { DecentApiContext } from '../contexts/DecentApiContext';
+import { skipToken } from '@tanstack/react-query';
 
-type FetchDaoParams = {
+type FetchDaoOptions = {
   chainId?: SupportedChainId;
   address?: Address;
 };
+
+type FetchDaoParams = FetchDaoOptions & TanstackQueryOptions
 
 /**
  * React hook to fetch a specific DAO.
@@ -20,18 +23,14 @@ type FetchDaoParams = {
  * @returns {QueryReturn<Dao>} Object with { data: Dao, isLoading: boolean, error: Error | null }
  */
 export const useFetchDao = (params: FetchDaoParams): QueryReturn<Dao> => {
-  const { chainId, address } = params;
+  const { chainId, address, enabled } = params;
   const { apiUrl } = useContext(DecentApiContext);
 
-  const shouldFetch = !!(chainId && address);
-  if (!shouldFetch) {
-    return { data: {} as Dao, isLoading: false, error: null };
-  }
+  const shouldFetch = !!(chainId && address) && enabled;
 
   const { data, error, isLoading } = useQuery({
     queryKey: ['dao', chainId, address, apiUrl],
-    queryFn: () => getDao({ chainId, address, apiUrl }),
-    enabled: shouldFetch,
+    queryFn: shouldFetch ? () => getDao({ chainId, address, apiUrl }) : skipToken,
     initialData: {} as Dao,
   });
 

--- a/src/react/hooks/useFetchDaos.ts
+++ b/src/react/hooks/useFetchDaos.ts
@@ -2,12 +2,15 @@ import { useContext, useQuery } from './imports';
 import { Dao } from '../../core/types/Dao';
 import { SupportedChainId } from '../../core/types/Chains';
 import { getAllDaos } from '../../core/fetch/dao';
-import { QueryReturn } from '../types';
+import { QueryReturn, TanstackQueryOptions } from '../types';
 import { DecentApiContext } from '../contexts/DecentApiContext';
+import { skipToken } from '@tanstack/react-query';
 
-type FetchDaosParams = {
+type FetchDaosOptions = {
   chainId?: SupportedChainId;
 };
+
+type FetchDaosParams = FetchDaosOptions & TanstackQueryOptions;
 
 /**
  * React hook to fetch all DAOs.
@@ -17,18 +20,14 @@ type FetchDaosParams = {
  * @returns {QueryReturn<Dao[]>} Object with { data: Dao[], isLoading: boolean, error: Error | null }
  */
 export const useFetchDaos = (params?: FetchDaosParams): QueryReturn<Dao[]> => {
-  const { chainId } = params ?? {};
+  const { chainId, enabled } = params ?? {};
   const { apiUrl } = useContext(DecentApiContext);
 
-  const shouldFetch = !!chainId;
-  if (!shouldFetch) {
-    return { data: [], isLoading: false, error: null };
-  }
+  const shouldFetch = !!chainId && enabled;
 
   const { data, error, isLoading } = useQuery({
     queryKey: ['daos', chainId, apiUrl],
-    queryFn: () => getAllDaos({ chainId, apiUrl }),
-    enabled: shouldFetch,
+    queryFn: shouldFetch ? () => getAllDaos({ chainId, apiUrl }) : skipToken,
     initialData: [],
   });
 

--- a/src/react/hooks/useFetchMe.ts
+++ b/src/react/hooks/useFetchMe.ts
@@ -1,8 +1,11 @@
 import { useContext, useQuery } from './imports';
 import { User } from '../../core/types/Api';
 import { me } from '../../core/fetch/auth';
-import { QueryReturn } from '../types';
+import { QueryReturn, TanstackQueryOptions } from '../types';
 import { DecentApiContext } from '../contexts/DecentApiContext';
+import { skipToken } from '@tanstack/react-query';
+
+type FetchMeParams = TanstackQueryOptions;
 
 type FetchMeResult = QueryReturn<User> & {
   refetch: () => Promise<User | undefined>;
@@ -13,18 +16,14 @@ type FetchMeResult = QueryReturn<User> & {
  *
  * @returns {FetchMeResult} Object with { data: User, isLoading: boolean, error: Error | null, refetch: Function }
  */
-export const useFetchMe = (): FetchMeResult => {
+export const useFetchMe = (params: FetchMeParams): FetchMeResult => {
   const { apiUrl } = useContext(DecentApiContext);
 
-  const shouldFetch = !!apiUrl;
-  if (!shouldFetch) {
-    return { data: {} as User, isLoading: false, error: null, refetch: async () => undefined };
-  }
+  const shouldFetch = !!apiUrl && params.enabled;
 
   const { data, error, isLoading, refetch: queryRefetch } = useQuery({
     queryKey: ['me', apiUrl],
-    queryFn: () => me({ apiUrl }),
-    enabled: shouldFetch,
+    queryFn: shouldFetch ? () => me({ apiUrl }) : skipToken,
     initialData: {} as User,
   });
 

--- a/src/react/hooks/useFetchProposal.ts
+++ b/src/react/hooks/useFetchProposal.ts
@@ -3,14 +3,17 @@ import { SupportedChainId } from '../../core/types/Chains';
 import { Proposal } from '../../core/types/Proposal';
 import { Address } from '../../core/types/Common';
 import { getProposal } from '../../core/fetch/proposal';
-import { QueryReturn } from '../types';
+import { QueryReturn, TanstackQueryOptions } from '../types';
 import { DecentApiContext } from '../contexts/DecentApiContext';
+import { skipToken } from '@tanstack/react-query';
 
-type FetchProposalParams = {
+type FetchProposalOptions = {
   chainId?: SupportedChainId;
   address?: Address;
   slug?: string;
 };
+
+type FetchProposalParams = FetchProposalOptions & TanstackQueryOptions;
 
 /**
  * React hook to fetch a specific proposal by its slug.
@@ -22,18 +25,14 @@ type FetchProposalParams = {
  * @returns {QueryReturn<Proposal>} Object with { data: Proposal, isLoading: boolean, error: Error | null }
  */
 export const useFetchProposal = (params: FetchProposalParams): QueryReturn<Proposal> => {
-  const { chainId, address, slug } = params;
+  const { chainId, address, slug, enabled } = params;
   const { apiUrl } = useContext(DecentApiContext);
 
-  const shouldFetch = !!(chainId && address && slug);
-  if (!shouldFetch) {
-    return { data: {} as Proposal, isLoading: false, error: null };
-  }
+  const shouldFetch = !!(chainId && address && slug) && enabled;
 
   const { data, error, isLoading } = useQuery({
     queryKey: ['proposal', chainId, address, slug, apiUrl],
-    queryFn: () => getProposal({ chainId, address, slug, apiUrl }),
-    enabled: shouldFetch,
+    queryFn: shouldFetch ? () => getProposal({ chainId, address, slug, apiUrl }) : skipToken,
     initialData: {} as Proposal,
   });
 

--- a/src/react/hooks/useFetchProposals.ts
+++ b/src/react/hooks/useFetchProposals.ts
@@ -3,13 +3,16 @@ import { SupportedChainId } from '../../core/types/Chains';
 import { Proposal } from '../../core/types/Proposal';
 import { Address } from '../../core/types/Common';
 import { getAllProposals } from '../../core/fetch/proposal';
-import { QueryReturn } from '../types';
+import { QueryReturn, TanstackQueryOptions } from '../types';
 import { DecentApiContext } from '../contexts/DecentApiContext';
+import { skipToken } from '@tanstack/react-query';
 
-type FetchProposalsParams = {
+type FetchProposalsOptions = {
   chainId?: SupportedChainId;
   address?: Address;
 }
+
+type FetchProposalsParams = FetchProposalsOptions & TanstackQueryOptions;
 
 /**
  * React hook to fetch all proposals for a specific DAO.
@@ -20,18 +23,14 @@ type FetchProposalsParams = {
  * @returns {QueryReturn<Proposal[]>} Object with { data: Proposal[], isLoading: boolean, error: Error | null }
  */
 export const useFetchProposals = (params: FetchProposalsParams): QueryReturn<Proposal[]> => {
-  const { chainId, address } = params;
+  const { chainId, address, enabled } = params;
   const { apiUrl } = useContext(DecentApiContext);
 
-  const shouldFetch = !!(chainId && address);
-  if (!shouldFetch) {
-    return { data: [], isLoading: false, error: null };
-  }
+  const shouldFetch = !!(chainId && address) && enabled;
 
   const { data, error, isLoading } = useQuery({
     queryKey: ['proposals', chainId, address, apiUrl],
-    queryFn: () => getAllProposals({ chainId, address, apiUrl }),
-    enabled: shouldFetch,
+    queryFn: shouldFetch ? () => getAllProposals({ chainId, address, apiUrl }) : skipToken,
     initialData: [],
   });
 

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -1,5 +1,9 @@
 export type QueryReturn<T> = {
-  data: T;
+  data: T | undefined;
   isLoading: boolean;
   error: Error | null;
 };
+
+export type TanstackQueryOptions = {
+  enabled: boolean
+}


### PR DESCRIPTION
### Changes

- All hooks now supports `enabled` parameter to disable hook, which uses [skipToken](https://tanstack.com/query/latest/docs/framework/react/guides/disabling-queries/#typesafe-disabling-of-queries-using-skiptoken).
- `QueryReturn` type now define `data` as `T | undefined` which brings more type safety than an empty object converted to type `T`.